### PR TITLE
Get ye some game logs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,4 @@ end
 gem 'haml'
 gem 'haml-rails'
 gem 'zurb-foundation'
+gem 'httparty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,9 @@ GEM
       haml (~> 4.0.0)
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
+    httparty (0.13.3)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     jbuilder (2.2.13)
       activesupport (>= 3.0.0, < 5)
@@ -88,6 +91,7 @@ GEM
     mini_portile (0.6.2)
     minitest (5.6.1)
     multi_json (1.11.0)
+    multi_xml (0.5.5)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     pg (0.18.2)
@@ -190,6 +194,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   haml
   haml-rails
+  httparty
   jbuilder (~> 2.0)
   jquery-rails
   pg

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,3 +1,12 @@
 class Game < ActiveRecord::Base
   belongs_to :player
+
+  def self.build_from_gamelog(gamelog, player_id)
+    formatted_gamelog = Stats::GamelogTranslator.new(gamelog, player_id).translate
+    new(filter_by_attributes(formatted_gamelog))
+  end
+
+  def self.filter_by_attributes(formatted_gamelog)
+    formatted_gamelog.select {|statistic, _value| Game.attribute_method? statistic }
+  end
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,3 +1,12 @@
 class Player < ActiveRecord::Base
   has_many :games
+
+  def fetch_unstored_games
+    game_finder = Stats::PlayerGameFinder.new(nba_stats_id)
+
+    game_finder.all_gamelogs.each do |gamelog|
+      next if Game.find_by_nba_stats_id gamelog[:game_id]
+      Game.build_from_gamelog(gamelog, id).save!
+    end
+  end
 end

--- a/app/models/stats/gamelog_translator.rb
+++ b/app/models/stats/gamelog_translator.rb
@@ -1,0 +1,23 @@
+module Stats
+  # Takes a hash of stats comprising a player's boxscore from
+  # stats.nba.com and reformats any fields that conflict with
+  # the Game class' attributes.
+  class GamelogTranslator
+    def initialize(gamelog, player_id)
+      @gamelog = gamelog
+      @player_id = player_id
+    end
+
+    def translate
+      game_stats = @gamelog.dup
+
+      # NBA's :game_id becomes :nba_stats_id
+      game_stats[:nba_stats_id] = @gamelog.delete :game_id
+      # :player_id should refer to our ID, not NBA's
+      game_stats[:player_id] = @player_id
+      game_stats[:win] = (@gamelog[:wl] == "W")
+
+      game_stats
+    end
+  end
+end

--- a/app/models/stats/player_game_finder.rb
+++ b/app/models/stats/player_game_finder.rb
@@ -1,0 +1,91 @@
+module Stats
+
+  # Queries the nba.com/stats API for a list of all of given player's games.
+  # Initialize with the player's nba.com ID (don't see a handy automated way
+  # to do this yet) and specify regular season or playoffs. The response is
+  # parsed into an array of game logs, where each game log is a Hash like the
+  # following:
+  #  {
+  #   :season_id=>"42009",
+  #   :player_id=>200765,
+  #   :game_id=>"0040900204",
+  #   :game_date=>"MAY 09, 2010",
+  #   :matchup=>"BOS vs. CLE",
+  #   :wl=>"W",
+  #   :min=>47,
+  #   :fgm=>9,
+  #   :fga=>21,
+  #   :oreb=>4,
+  #   :dreb=>14,
+  #   :reb=>18,
+  #   :ast=>13,
+  #   :stl=>2,
+  #   :blk=>0,
+  #   :tov=>4,
+  #   :pf=>2,
+  #   :pts=>29,
+  #   :plus_minus=>14,
+  #   :video_available=>0
+  #  }.merge({
+  #   :playoffs=>true
+  #  })
+  #
+  class PlayerGameFinder < Stats::StatFinder
+
+    REGULAR_SEASON = "Regular Season"
+    PLAYOFFS       = "Playoffs"
+
+    def initialize(player_id)
+      @endpoint = "/playergamelog"
+      @options  = {query: {
+        "LeagueID" => "00",
+        "PlayerID" => player_id,
+        "Season" => "ALL"
+      }}
+    end
+
+    def all_gamelogs
+      all_regular_season_gamelogs + all_playoff_gamelogs
+    end
+
+    def all_regular_season_gamelogs
+      all_games_of_type(playoffs: false)
+    end
+
+    def all_playoff_gamelogs
+      all_games_of_type(playoffs: true)
+    end
+
+    protected
+
+    def all_games_of_type(type_tag = {})
+      raise "type_tag must have key :playoffs" unless type_tag.has_key? :playoffs
+
+      type = (type_tag[:playoffs] ? PLAYOFFS : REGULAR_SEASON)
+
+      extract_game_list(query(type)).map { |game| game.merge(type_tag) }
+    end
+
+    def extract_game_list(response)
+      headers_and_rows = response["resultSets"].first
+
+      hashify(zip(headers_and_rows))
+    end
+
+    def query(season_type)
+      season_option = {query: {"SeasonType" => season_type}}
+      get(@endpoint, @options.deep_merge(season_option)).parsed_response
+    end
+
+    def zip(headers_and_rows)
+      headers_and_rows["rowSet"].map {|row| headers_and_rows["headers"].zip(row)}
+    end
+
+    def hashify(zipped_gamelogs)
+      zipped_gamelogs.map do |gamelog|
+        gamelog.map! {|stat| [stat.first.downcase.to_sym, stat.last]}
+        Hash[gamelog]
+      end
+    end
+  end
+end

--- a/app/models/stats/stat_finder.rb
+++ b/app/models/stats/stat_finder.rb
@@ -1,0 +1,10 @@
+module Stats
+  class StatFinder
+    include HTTParty
+    base_uri 'stats.nba.com/stats'
+
+    def get(endpoint, options = {})
+      self.class.get(endpoint, options)
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,25 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+# WHEREAS
+#   the first viz will be plotting the career scoring totals of the top ten
+#   career scorers, with (x, y) axes of (games played, points scored); and
+# WHEREAS
+#   it seems awfully rude to grab a shitload of players all at once from
+#   someone else's API;
+# BE IT RESOLVED
+#   to just grab those ten dudes' games in this here seeds file.
+
+top_ten_scorers = {
+  "Kareem Abdul-Jabbar" => "76003",
+  "Karl Malone"         => "252",
+  "Kobe Bryant"         => "977",
+  "Michael Jordan"      => "893",
+  "Wilt Chamberlain"    => "76375",
+  "Shaquille O'Neal"    => "406",
+  "Dirk Nowitzki"       => "1717",
+  "Moses Malone"        => "77449",
+  "Elvin Hayes"         => "76979",
+  "Hakeem Olajuwon"     => "165"
+}
+
+top_ten_scorers.each do |name, nba_stats_id|
+  Player.create!(name: name, nba_stats_id: nba_stats_id).fetch_unstored_games
+end


### PR DESCRIPTION
Hard to build an NBA stats app without NBA stats, after all. ¯\\\_(ツ)\_/¯

## :scroll: The Actual Feature
A `Player` instance can fetch all of its player's gamelogs from stats.nba.com. Having done so, it iterates through those gamelogs and, for each that isn't already persisted in the DB, has the `Game` class build an instance from those stats and saves the new record.

Plus, `seeds.rb` has the names and remote ids of the top 10 career scorers, so the app can go ahead and create records for them and all their games.

### :memo: Which Entails What, Exactly?
First, encapsulating the API requests for stats.nba.com in a service object: `Player` should be able to grab its games, but it shouldn't care how, so if a better source of stats comes along, it can be swapped in painlessly. Nor should it care about turning those stats into an actual `Game` object: that's the business of the `Game` class.

That said, the `Game` class shouldn't need to know about how some foreign API formats its boxscores, so reformatting a gamelog to resolve any differences in field name or data format is delegated to a service object, too.

The specific structure of a query for some player's gamelogs is in its own class, but it inherits all the generic configuration for hitting that API from a superclass so other queries (Team stats! Player season stats!) can be made easily, with a minimum of repeated boilerplate.

### :clipboard: Which is Implemented How?

* Add `HTTParty` to Gemfile for building API queries nicely.
* Stick a few new Plain Old Ruby classes in their own module (and `/models` subdirectory), `/stats`
  - `Stats::StatFinder`, a base class that sets basic config all specific queries will share:
    1. `include HTTParty` module
    2. sets `base_uri` for all queries, so subclasses can just specify an endpoint and some options
    3. for convenience, defines an alias for `HTTParty`'s class method `get`
  - `Stats::PlayerGameFinder`, a subclass of `StatFinder` which does what it says on the tin.
  - `Stats::GamelogTranslator`, which changes conflicting key names and value data from a hash of stats.nba.com stats to match the attributes of the `Game` class.
* Define `Game::build_from_gamelog` which, given a hash of nba.com stats and a `player_id`*, instantiates a `Game` object
* Define `Player#fetch_unstored_games` which gets all gamelogs for a player and `create!`s a `Game` for each that doesn't currently exist.
* `db/seeds` has a hash of the `"name" => "nba_stats_id"` for each of the top 10 career scoring leaders it iterates through.


\* That's `player_id` the local primary key, not the stats.nba.com remote id of the same name.