### PR TITLE
Get ye some game logs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,4 @@ end
 gem 'haml'
 gem 'haml-rails'
 gem 'zurb-foundation'
+gem 'httparty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,9 @@ GEM
       haml (~> 4.0.0)
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
+    httparty (0.13.3)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     jbuilder (2.2.13)
       activesupport (>= 3.0.0, < 5)
@@ -88,6 +91,7 @@ GEM
     mini_portile (0.6.2)
     minitest (5.6.1)
     multi_json (1.11.0)
+    multi_xml (0.5.5)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     pg (0.18.2)
@@ -190,6 +194,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   haml
   haml-rails
+  httparty
   jbuilder (~> 2.0)
   jquery-rails
   pg

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,3 +1,12 @@
 class Game < ActiveRecord::Base
   belongs_to :player
+
+  def self.build_from_gamelog(gamelog, player_id)
+    formatted_gamelog = Stats::GamelogTranslator.new(gamelog, player_id).translate
+    new(filter_by_attributes(formatted_gamelog))
+  end
+
+  def self.filter_by_attributes(formatted_gamelog)
+    formatted_gamelog.select {|statistic, _value| Game.attribute_method? statistic }
+  end
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,3 +1,12 @@
 class Player < ActiveRecord::Base
   has_many :games
+
+  def fetch_unstored_games
+    game_finder = Stats::PlayerGameFinder.new(nba_stats_id)
+
+    game_finder.all_gamelogs.each do |gamelog|
+      next if Game.find_by_nba_stats_id gamelog[:game_id]
+      Game.build_from_gamelog(gamelog, id).save!
+    end
+  end
 end

--- a/app/models/stats/gamelog_translator.rb
+++ b/app/models/stats/gamelog_translator.rb
@@ -1,0 +1,23 @@
+module Stats
+  # Takes a hash of stats comprising a player's boxscore from
+  # stats.nba.com and reformats any fields that conflict with
+  # the Game class' attributes.
+  class GamelogTranslator
+    def initialize(gamelog, player_id)
+      @gamelog = gamelog
+      @player_id = player_id
+    end
+
+    def translate
+      game_stats = @gamelog.dup
+
+      # NBA's :game_id becomes :nba_stats_id
+      game_stats[:nba_stats_id] = @gamelog.delete :game_id
+      # :player_id should refer to our ID, not NBA's
+      game_stats[:player_id] = @player_id
+      game_stats[:win] = (@gamelog[:wl] == "W")
+
+      game_stats
+    end
+  end
+end

--- a/app/models/stats/player_game_finder.rb
+++ b/app/models/stats/player_game_finder.rb
@@ -1,0 +1,91 @@
+module Stats
+
+  # Queries the nba.com/stats API for a list of all of given player's games.
+  # Initialize with the player's nba.com ID (don't see a handy automated way
+  # to do this yet) and specify regular season or playoffs. The response is
+  # parsed into an array of game logs, where each game log is a Hash like the
+  # following:
+  #  {
+  #   :season_id=>"42009",
+  #   :player_id=>200765,
+  #   :game_id=>"0040900204",
+  #   :game_date=>"MAY 09, 2010",
+  #   :matchup=>"BOS vs. CLE",
+  #   :wl=>"W",
+  #   :min=>47,
+  #   :fgm=>9,
+  #   :fga=>21,
+  #   :oreb=>4,
+  #   :dreb=>14,
+  #   :reb=>18,
+  #   :ast=>13,
+  #   :stl=>2,
+  #   :blk=>0,
+  #   :tov=>4,
+  #   :pf=>2,
+  #   :pts=>29,
+  #   :plus_minus=>14,
+  #   :video_available=>0
+  #  }.merge({
+  #   :playoffs=>true
+  #  })
+  #
+  class PlayerGameFinder < Stats::StatFinder
+
+    REGULAR_SEASON = "Regular Season"
+    PLAYOFFS       = "Playoffs"
+
+    def initialize(player_id)
+      @endpoint = "/playergamelog"
+      @options  = {query: {
+        "LeagueID" => "00",
+        "PlayerID" => player_id,
+        "Season" => "ALL"
+      }}
+    end
+
+    def all_gamelogs
+      all_regular_season_gamelogs + all_playoff_gamelogs
+    end
+
+    def all_regular_season_gamelogs
+      all_games_of_type(playoffs: false)
+    end
+
+    def all_playoff_gamelogs
+      all_games_of_type(playoffs: true)
+    end
+
+    protected
+
+    def all_games_of_type(type_tag = {})
+      raise "type_tag must have key :playoffs" unless type_tag.has_key? :playoffs
+
+      type = (type_tag[:playoffs] ? PLAYOFFS : REGULAR_SEASON)
+
+      extract_game_list(query(type)).map { |game| game.merge(type_tag) }
+    end
+
+    def extract_game_list(response)
+      headers_and_rows = response["resultSets"].first
+
+      hashify(zip(headers_and_rows))
+    end
+
+    def query(season_type)
+      season_option = {query: {"SeasonType" => season_type}}
+      get(@endpoint, @options.deep_merge(season_option)).parsed_response
+    end
+
+    def zip(headers_and_rows)
+      headers_and_rows["rowSet"].map {|row| headers_and_rows["headers"].zip(row)}
+    end
+
+    def hashify(zipped_gamelogs)
+      zipped_gamelogs.map do |gamelog|
+        gamelog.map! {|stat| [stat.first.downcase.to_sym, stat.last]}
+        Hash[gamelog]
+      end
+    end
+  end
+end

--- a/app/models/stats/stat_finder.rb
+++ b/app/models/stats/stat_finder.rb
@@ -1,0 +1,10 @@
+module Stats
+  class StatFinder
+    include HTTParty
+    base_uri 'stats.nba.com/stats'
+
+    def get(endpoint, options = {})
+      self.class.get(endpoint, options)
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,25 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+# WHEREAS
+#   the first viz will be plotting the career scoring totals of the top ten
+#   career scorers, with (x, y) axes of (games played, points scored); and
+# WHEREAS
+#   it seems awfully rude to grab a shitload of players all at once from
+#   someone else's API;
+# BE IT RESOLVED
+#   to just grab those ten dudes' games in this here seeds file.
+
+top_ten_scorers = {
+  "Kareem Abdul-Jabbar" => "76003",
+  "Karl Malone"         => "252",
+  "Kobe Bryant"         => "977",
+  "Michael Jordan"      => "893",
+  "Wilt Chamberlain"    => "76375",
+  "Shaquille O'Neal"    => "406",
+  "Dirk Nowitzki"       => "1717",
+  "Moses Malone"        => "77449",
+  "Elvin Hayes"         => "76979",
+  "Hakeem Olajuwon"     => "165"
+}
+
+top_ten_scorers.each do |name, nba_stats_id|
+  Player.create!(name: name, nba_stats_id: nba_stats_id).fetch_unstored_games
+end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -1,5 +1,56 @@
 require 'rails_helper'
 
 RSpec.describe Game, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe ".build_from_gamelog" do
+    before :each do
+      @fab = Player.create(name: "Fab Melo", nba_stats_id: "203097")
+      @gamelog = {
+        :season_id=>"22012",
+        :player_id=>203097,
+        :game_id=>"0021200686",
+        :game_date=>"FEB 01, 2013",
+        :matchup=>"BOS vs. ORL",
+        :wl=>"W",
+        :min=>3,
+        :fgm=>0,
+        :fga=>0,
+        :fg_pct=>0.0,
+        :fg3m=>0,
+        :fg3a=>0,
+        :fg3_pct=>0.0,
+        :ftm=>0,
+        :fta=>0,
+        :ft_pct=>0.0,
+        :oreb=>0,
+        :dreb=>0,
+        :reb=>0,
+        :ast=>0,
+        :stl=>1,
+        :blk=>0,
+        :tov=>0,
+        :pf=>0,
+        :pts=>0,
+        :plus_minus=>-1,
+        :video_available=>1,
+        :playoffs=>false
+      }
+      @new_game = Game.build_from_gamelog(@gamelog, @fab.id)
+    end
+
+    it "returns a game instance" do
+      expect(@new_game.class).to eq Game
+    end
+
+    it "doesn't persist the new game" do
+      expect(@new_game.new_record?).to be true
+    end
+
+    it "converts :player_id to primary key" do
+      expect(@new_game.player_id).to eq @fab.id
+    end
+
+    it "converts :wl to :win" do
+      expect(@new_game.win).to be true
+    end
+  end
 end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -1,5 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe Player, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before :each do
+    @fab = Player.create(name: "Fab Melo", nba_stats_id: "203097")
+  end
+  describe "#fetch_unstored_games" do
+    it "doesn't have any games before fetching" do
+      expect(@fab.games.count).to eq(0)
+    end
+
+    it "adds all of a player's games" do
+      @fab.fetch_unstored_games
+
+      expect(@fab.games.count).to eq(6)
+    end
+
+    it "doesn't re-add existing games" do
+      2.times { @fab.fetch_unstored_games }
+
+      expect(@fab.games.count).to eq(6)
+    end
+  end
 end


### PR DESCRIPTION
Because making NBA stats visualizations without NBA stats is a tricky proposition.
## :scroll: The Actual Feature

`Player` instances can call a method `fetch_unstored_games` which will query an API for the boxscores for that player for each of their games, have the `Game` model build a new instance for any games that don't already have persisted records, and save the new records. And `seeds.rb` goes ahead and fetches all the games for the top 10 career scoring leaders.
## :memo: Which Entails What, Exactly?

A bunch of service objects, mainly. The `stats` module introduces three new non-ActiveRecord classes in `/app/models/stats` to encapsulate all interactions with the external API whence the stats come. The models themselves remain blissfully unaware of the API. Model-wise, changing to a different source for stats is as simple as swapping in new service objects (it would also probably entail a migration or two).
## :clipboard: Which Is Implemented How?
- `Stats::StatFinder`, a base class for generic configuration any specific queries will share. It includes `HTTParty`, sets the `base_uri` for queries, and provides a `get` method as a convenient alias for `HTTParty`'s `self.class.get`.
- `Stats::PlayerGameFinder`, a subclass of `StatFinder` that does what it says on the tin. Used by `Player` instances to fetch gamelogs.
- `Stats::GamelogTranslator`, which encapsulates the reformatting needed to resolve field name and data type conflicts between API response and model (e.g. `:win => true` instead of `:wl => "W"` and `:nba_stats_id => #{some_id}` instead of `:player_id => #{some_id}`). Used by `Game` class to build instances from the aforementioned gamelogs.
