### PR TITLE
Add indexes/foreign key constraints to remote ids, boolean flags, foreign key

### DIFF
--- a/db/migrate/20150515230828_create_players.rb
+++ b/db/migrate/20150515230828_create_players.rb
@@ -2,7 +2,7 @@ class CreatePlayers < ActiveRecord::Migration
   def change
     create_table :players do |t|
       t.string :name
-      t.string :nba_stats_id
+      t.string :nba_stats_id, index: true
 
       t.timestamps null: false
     end

--- a/db/migrate/20150515230843_create_games.rb
+++ b/db/migrate/20150515230843_create_games.rb
@@ -1,11 +1,11 @@
 class CreateGames < ActiveRecord::Migration
   def change
     create_table :games do |t|
-      t.references :player
-      t.string     :nba_stats_id
+      t.belongs_to :player,       index: true, foreign_key: true
+      t.string     :nba_stats_id, index: true
       t.string     :game_date
-      t.boolean    :playoffs
-      t.boolean    :win
+      t.boolean    :playoffs,     index: true
+      t.boolean    :win,          index: true
       t.integer    :pts
       t.integer    :fga
       t.integer    :fgm

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,6 +46,11 @@ ActiveRecord::Schema.define(version: 20150515230843) do
     t.datetime "updated_at",   null: false
   end
 
+  add_index "games", ["nba_stats_id"], name: "index_games_on_nba_stats_id", using: :btree
+  add_index "games", ["player_id"], name: "index_games_on_player_id", using: :btree
+  add_index "games", ["playoffs"], name: "index_games_on_playoffs", using: :btree
+  add_index "games", ["win"], name: "index_games_on_win", using: :btree
+
   create_table "players", force: :cascade do |t|
     t.string   "name"
     t.string   "nba_stats_id"
@@ -53,4 +58,7 @@ ActiveRecord::Schema.define(version: 20150515230843) do
     t.datetime "updated_at",   null: false
   end
 
+  add_index "players", ["nba_stats_id"], name: "index_players_on_nba_stats_id", using: :btree
+
+  add_foreign_key "games", "players"
 end


### PR DESCRIPTION
The remote ids (i.e. `nba_stats_id` columns) will be searched regularly with API calls; filtering games by regular season/playoffs and win/loss is a pretty fundamental thing; and games will be queried by their foreign key all the dang time. In each case, having an index will be awfully handy viz. performance.
